### PR TITLE
WT-10186 Update fabfile install to take a wiredtiger branch and testy branch as arguments

### DIFF
--- a/fabfile.py
+++ b/fabfile.py
@@ -260,7 +260,7 @@ def git_clone(c, git_url, local_dir, branch):
         print(f"Directory '{local_dir}' exists. " \
               f"Repository '{repo}' will not be cloned.")
     else:
-        print(f"Cloning branch '{branch}' of '{repo}' repository")
+        print(f"Cloning branch '{branch}' of '{repo}' repository ...")
         if c.run(f"git clone --branch {branch} {git_url} {local_dir}", warn=True):
             print("Success!")
         else:


### PR DESCRIPTION
- Updated the `install` function in `fabfile.py` to take two arguments: the wiredtiger repository branch (`wiredtiger_branch`) and the testy repository branch (`testy_branch`). Their default values are `develop` and `main`, respectively.
- Updated the `git_clone` function in `fabfile.py` to take an additional `branch` argument, and added error messaging if the clone fails.

Example usage:
```
$ fab install --wiredtiger-branch=develop --testy-branch=wt-10186-update-install-arguments
```
Note that Fabric converts the underscores in the argument names to dashes on the command line.