### PR TITLE
WT-10220 Remove get_testy_service_name function

### DIFF
--- a/fabfile.py
+++ b/fabfile.py
@@ -175,6 +175,7 @@ def workload(c, upload=None, list=False, describe=None):
             try: 
                 c.put(upload, "/tmp", preserve_mode=True)
             except Exception as e:
+                print(e)
                 print(f"Upload failed for workload '{workload_name}'.")
             else:
                 copy = c.sudo(f"cp /tmp/{upload} {src}", user=user, warn=True)


### PR DESCRIPTION
The `get_testy_service_name` returns the name of the testy service based on the value of the active workload. If the `current_workload` value is not set in the `.testy` configuration, the service name is invalid. This can happen when the `populate` or `start` functions are called for the first time.

This change removes the `get_testy_service_name`  function as it was creating additional overhead in the code. The `populate` and `start` commands need to first test if the service is running with the current workload, and if not, then run the command with the user-specified workload. 