### PR TITLE
WT-10094 Implement the update function in fabfile.py

### DIFF
--- a/fabfile.py
+++ b/fabfile.py
@@ -190,7 +190,9 @@ def update(c, wiredtiger_branch=None, testy_branch=None):
             print(f"\nFailed to update {testy} to branch '{testy_branch}'.")
             update_success = False
         finally:
-            # Restore configuration values.
+            # The update_testy function may fail after updating the remote configuration
+            # file. Make sure the pre-update configuration values are restored on both
+            # failure and success.
             set_value(c, "application", "current_workload", workload)
 
     if wiredtiger_branch:


### PR DESCRIPTION
The update command requires one or two arguments: `wiredtiger_branch` and `testy_branch`. Example usage is as follows:
```
$ fab update --testy_branch=main
$ fab update --wiredtiger_branch=mongodb-7.0
$ fab update --wiredtiger_branch=mongodb-7.0 --testy_branch=main
```
Updates may be performed at any time. You may update to either a specific branch or commit. There are no default values. If an argument is not specified, no update to that branch will be made.

Updates to WiredTiger are performed in line with the WiredTiger source documentation for [upgrading and downgrading databases](https://source.wiredtiger.com/develop/upgrade.html). The specified branch or commit is checked out and built, the application is stopped, the new version of the WiredTiger shared library is installed, and the application is started. The command fails if any of the aforementioned items fail to execute.
