### PR TITLE
WT-10246 Use a previous commit when updating a branch fails fab update

### DIFF
--- a/fabfile.py
+++ b/fabfile.py
@@ -571,10 +571,10 @@ def update_wiredtiger(c, branch):
     old_branch = None
     with c.cd(wt_home_dir):
         result = c.run("git rev-parse --abbrev-ref HEAD", hide=True)
-        commit = c.run("git rev-parse HEAD", hide=True)
         if not result.stdout:
             raise Exit(f"Error: {wiredtiger} is not currently on a branch.")
         old_branch = result.stdout.strip()
+        commit = c.run("git rev-parse HEAD", hide=True)
         commit_hash = commit.stdout.strip()
 
     # Check out branch from GitHub.
@@ -589,10 +589,9 @@ def update_wiredtiger(c, branch):
         print(f"\nAttempting to restore branch '{old_branch}' ...")
         # If we are on the same branch and the new commits breaks, use an older working commit.
         if old_branch == branch:
-            print(commit_hash, "commit")
             if git_checkout(c, wt_home_dir, commit_hash) and \
             build_wiredtiger(c, wt_home_dir, wt_build_dir, commit_hash):
-                print(f"Restored {wiredtiger} to previous {branch} commit {commit_hash} ")
+                print(f"Restored {wiredtiger} branch '{branch}' to the previous commit.")
         elif git_checkout(c, wt_home_dir, old_branch) and \
            build_wiredtiger(c, wt_home_dir, wt_build_dir, old_branch):
             print(f"Restored {wiredtiger} to branch '{branch}'.")


### PR DESCRIPTION
We use a previous commit hash when the current branch does a pull and the build fails. As we cannot undo a pull, and the branch is updated to a newer commit we will use an older commit and check that out in a detached state. This will not create a new branch on the repository, but will act like a branch for the remote framework to use. This can then be updated to a newer branch, or be used if an update to a newer branch fails, which can act as an `old_branch`. 