### PR TITLE
WT-10209 Implement single insert/update of the run phase

### DIFF
--- a/workloads/sample/sample_run.py
+++ b/workloads/sample/sample_run.py
@@ -47,9 +47,9 @@ insert_thread = Thread(10*insert_op_1 + 5*insert_op_2 + insert_op_3)
 update_op_1 = Operation(Operation.OP_UPDATE, Key(Key.KEYGEN_PARETO, 512, ParetoOptions(1)),
             Value(1024)) + Operation(Operation.OP_SLEEP, "10")
 update_op_2 = Operation(Operation.OP_UPDATE, Key(Key.KEYGEN_PARETO, 512, ParetoOptions(1)),
-            Value(1024)) + Operation(Operation.OP_SLEEP, "10")
+            Value(1000*1024)) + Operation(Operation.OP_SLEEP, "30")
 update_op_3 = Operation(Operation.OP_UPDATE, Key(Key.KEYGEN_PARETO, 512, ParetoOptions(1)),
-            Value(1024)) + Operation(Operation.OP_SLEEP, "10")
+            Value(100000*1024)) + Operation(Operation.OP_SLEEP, "60")
 update_thread = Thread(10*update_op_1 + 5*update_op_2 + update_op_3)
 
 # Define the workload operations.


### PR DESCRIPTION
This change defines insert and update operations for the workgen workload. I also updated the `wiredtiger_open` configuration to checkpoint every 60 seconds. enable logging, and to create the database if not already existing (so that the `run` can operate without first calling `populate`).