### PR TITLE
WT-10501 Disable the generation of stats for the sample workload

### DIFF
--- a/workloads/sample/sample_populate.py
+++ b/workloads/sample/sample_populate.py
@@ -130,6 +130,10 @@ while current_db_size < target_db_size and not thread_exit.is_set():
     # The next generated key/value pair may not fit in the randomly generated size, simply retry if
     # this is the case.
     pop_workload = Workload(context, thread)
+
+    # Disable generation of stats.
+    pop_workload.options.report_enabled = False
+
     try:
         pop_workload.run(connection)
         current_db_size += (key_size + value_size)

--- a/workloads/sample/sample_run.py
+++ b/workloads/sample/sample_run.py
@@ -66,6 +66,9 @@ delete_thread = Thread(delete_op)
 workload = Workload(context, 10*insert_thread + 10*update_thread + 10*read_thread + \
      5*delete_thread)
 
+# Disable generation of stats.
+workload.options.report_enabled = False
+
 # Add a prefix to the table names.
 workload.options.create_prefix = "table_"
 


### PR DESCRIPTION
This prevents the creation of the `workload.stat` that would get bigger and bigger over time.