### PR TITLE
WT-10147 Update the install functionality to work with EC2 Linux distributions

### DIFF
--- a/fabfile.py
+++ b/fabfile.py
@@ -592,7 +592,7 @@ def install_packages(c, release):
     elif release.startswith("CentOS Linux 7"):
         c.sudo(f"{installer} -y update", warn=True, hide=True)
         packages = ["centos-release-scl", "devtoolset-9-gcc", "devtoolset-9-gcc-c++", "git",
-                    "python3-devel", "swig", "libarchive"]
+                    "python3-devel", "libarchive"]
         for package in packages:
             if c.run(f"{installer} list installed {package}", warn=True, hide=True):
                 print(f" -- Package '{package}' is already the newest version.", flush=True)


### PR DESCRIPTION
Updated the `install` function in `fabfile.py` to work on EC2 instances running Amazon Linux 2, CentOS 7, RHEL 8, and Ubuntu 18.04/20.04/22.04 and tested installation against all six distros.