### PR TITLE
WT-10539 Update service template substitution code in fabfile.py

### DIFF
--- a/services/testy-backup@.timer
+++ b/services/testy-backup@.timer
@@ -5,7 +5,6 @@ After=testy-run@%i.service
 [Timer]
 OnActiveSec=86400s
 OnUnitActiveSec=86400s
-Unit=testy-backup@%i.service
 
 [Install]
 WantedBy=timers.target


### PR DESCRIPTION
Added new function to get service name for the instance rather than using `systemd-escape` as the system function did not work as intended on AL2 which has an older `systemd` version. Also removed a definition in the testy-backup@.timer file that was not needed and causing warnings in the system log.