### PR TITLE
WT-10632 Create the correct tags when launching a testy server

### DIFF
--- a/.testy
+++ b/.testy
@@ -12,15 +12,14 @@ script_dir         = ${home_dir}/scripts
 service_dir        = ${home_dir}/services
 workload_dir       = ${home_dir}/workloads
 service_script_dir = ${home_dir}/services/scripts
-
-git_url        = git@github.com:wiredtiger/testy.git
-parse_script   = ${script_dir}/testy_parse.py
-unpack_script  = ${script_dir}/testy_unpack.py
-testy_service  = ${service_dir}/testy-run@.service
-crash_service  = ${service_dir}/testy-crash@.service
-crash_timer    = ${service_dir}/testy-crash@.timer
-backup_service = ${service_dir}/testy-backup@.service
-backup_timer   = ${service_dir}/testy-backup@.timer
+parse_script       = ${script_dir}/testy_parse.py
+unpack_script      = ${script_dir}/testy_unpack.py
+testy_service      = ${service_dir}/testy-run@.service
+crash_service      = ${service_dir}/testy-crash@.service
+crash_timer        = ${service_dir}/testy-crash@.timer
+backup_service     = ${service_dir}/testy-backup@.service
+backup_timer       = ${service_dir}/testy-backup@.timer
+git_url            = git@github.com:wiredtiger/testy.git
 
 [wiredtiger]
 home_dir  = ${application:testy_dir}/wiredtiger

--- a/scripts/testy_launch.py
+++ b/scripts/testy_launch.py
@@ -70,7 +70,7 @@ def get_tag_value_from_resource(resource_id, key):
         raise Exit(result.stderr)
     value = result.stdout.strip()
     if not value:
-        raise Exit(f"Unable to retrieve value for key '{key} from resource '{resource_id}'")
+        raise Exit(f"Unable to retrieve value for key '{key}' from resource '{resource_id}'")
     return value
 
 def get_volume_id_from_instance(instance_id):

--- a/scripts/testy_launch.py
+++ b/scripts/testy_launch.py
@@ -128,6 +128,13 @@ def wait_on_status_check(instance_id):
 
     while retry < max_retries:
 
+        # AWS reports two statuses on EC2 instances, a "system status" and an "instance
+        # status", to identify hardware and software issues. When an instance is launched,
+        # the below aws cli call returns an empty list ([]) until the instance is running.
+        # Once the instance is running, the cli returns a nested list containing a text
+        # description of the two statuses, e.g. [['initializing', 'initializing']]. The
+        # instance is ready for use when both status checks have passed, which is reflected
+        # by the cli output of [['ok', 'ok']].
         result = local(f"aws ec2 describe-instance-status \
             --instance-ids {instance_id} \
             --query 'InstanceStatuses[*].[InstanceStatus.Status,SystemStatus.Status]' \

--- a/scripts/testy_launch.py
+++ b/scripts/testy_launch.py
@@ -151,11 +151,16 @@ def wait_on_status_check(instance_id):
         raise Exit(f"The status check failed to complete successfully after "
             f"{max_retries*sleep_time} seconds. Please check the AWS console.")
 
+# The following two functions are called from the fabfile and implement launching an
+# instance in AWS EC2 from either a launch template (analogous to an Evergreen "distro")
+# or from a snapshot ID. The functions return a python dictionary that contains information
+# relevant to the user executing the fab commands. The dictionary always includes the exit
+# status of the function, which is zero on success and non-zero on failure. On success,
+# the dictionary contains the necessary information for the user to log in to the
+# instance via ssh and identify the instance on the AWS console. On failure, the dictionary
+# contains a user-friendly error message.
+
 # Launch an AWS instance given a distro.
-# This function returns a dictionary with a 'status' field that is set to 0 when the instance
-# is launched successfully. In the successful case, the dictionary also contains information
-# about the newly launched instance. Upon failure, the 'status' field is non-zero and the 'msg'
-# field contains the error message.
 def launch_from_distro(distro):
 
     if not launch_template_exists(distro):
@@ -196,10 +201,6 @@ def launch_from_distro(distro):
         "instance_id": instance_id, "instance_name": instance_name}
 
 # Launch an AWS instance from a snapshot ID.
-# This function returns a dictionary with a 'status' field that is set to 0 when the instance
-# is launched successfully. In the successful case, the dictionary also contains information
-# about the newly launched instance. Upon failure, the 'status' field is non-zero and the 'msg'
-# field contains the error message.
 def launch_from_snapshot(snapshot_id):
 
     if not snapshot_exists(snapshot_id):

--- a/scripts/testy_launch.py
+++ b/scripts/testy_launch.py
@@ -118,7 +118,7 @@ def snapshot_exists(snapshot_id):
     return True if result.stdout.strip() else False
 
 def wait_on_status_check(instance_id):
-    max_retries = 30
+    max_retries = 60
     sleep_time = 10
     retry = 0
 
@@ -201,7 +201,6 @@ def launch_from_distro(distro):
         user = get_tag_value_from_resource(instance_id, "User")
 
     except Exception as e:
-        print("Failed.", flush=True)
         return {"status": 1, "msg": str(e).strip()}
 
     return {"status": 0, "user": user, "hostname": hostname,
@@ -261,7 +260,6 @@ def launch_from_snapshot(snapshot_id):
         user = get_tag_value_from_resource(instance_id, "User")
 
     except Exception as e:
-        print("Failed.", flush=True)
         return {"status": 1, "msg": str(e).strip()}
 
     return {"status": 0, "user": user, "hostname": hostname,

--- a/services/scripts/testy-snapshot.sh
+++ b/services/scripts/testy-snapshot.sh
@@ -44,6 +44,9 @@ main() {
     local _tags
     _tags=$(aws ec2 describe-instances --instance-ids "$_instance_id" \
         --query "Reservations[*].Instances[*].Tags[][]" --output json)
+    # The json output from the aws cli call is not in the correct format for input to
+    # an aws cli call. We need to strip the double quotes from the output and replace
+    # the colons with equal signs.
     _tags="${_tags//\"/}"
     _tags="${_tags//:/=}"
 

--- a/services/scripts/testy-snapshot.sh
+++ b/services/scripts/testy-snapshot.sh
@@ -10,10 +10,8 @@ main() {
     local _availability_zone
 
     _aws_endpoint="http://169.254.169.254/latest/meta-data/"
-    #_instance_id=$(curl ${_aws_endpoint}/instance-id 2> /dev/null)
-    #_availability_zone=$(curl ${_aws_endpoint}/placement/availability-zone 2> /dev/null)
-    _instance_id=i-079587865bf160bec
-    _availability_zone=ap-southeast-2c
+    _instance_id=$(curl ${_aws_endpoint}/instance-id 2> /dev/null)
+    _availability_zone=$(curl ${_aws_endpoint}/placement/availability-zone 2> /dev/null)
 
     echo "Starting database backup for instance '$_instance_id' ..."
 


### PR DESCRIPTION
Updated the code so that all resources have the same tags and resource names are consistent. Instances and volumes created from an AWS launch template inherit the tags defined in "Resource Tags", so there is no need to define them in the testy code.