### PR TITLE
WTBUILD-102 Automatically delete successfully validated snapshots

### DIFF
--- a/scripts/testy_launch.py
+++ b/scripts/testy_launch.py
@@ -36,7 +36,7 @@ def get_launch_templates():
 # Get all the available snapshots and return the result as a list.
 def get_snapshots():
     result = local("aws ec2 describe-snapshots \
-        --filter 'Name=tag:Application,Values=testy' \
+        --filters 'Name=tag:Application,Values=testy' \
         --query 'Snapshots[*].SnapshotId' \
         --output text", hide=True, warn=True)
     if result.stderr:
@@ -63,7 +63,7 @@ def set_tag_for_resource(resource_id, key, value):
 
 def get_tag_value_from_resource(resource_id, key):
     result = local(f"aws ec2 describe-tags \
-        --filter 'Name=resource-id,Values={resource_id}' \
+        --filters 'Name=resource-id,Values={resource_id}' \
         --query 'Tags[?Key==`{key}`].Value' \
         --output text", hide=True, warn=True)
     if result.stderr:
@@ -87,7 +87,7 @@ def get_volume_id_from_instance(instance_id):
 def launch_template_exists(launch_template_name):
     result = local(f"aws ec2 describe-launch-templates \
         --launch-template-names {launch_template_name} \
-        --filter 'Name=tag:Application,Values=testy' \
+        --filters 'Name=tag:Application,Values=testy' \
         --query 'LaunchTemplates[*].LaunchTemplateName' \
         --output text", hide=True, warn=True)
     if result.stderr:
@@ -110,7 +110,7 @@ def register_image_from_snapshot(image_name, architecture, snapshot_id):
 def snapshot_exists(snapshot_id):
     result = local(f"aws ec2 describe-snapshots \
         --snapshot-ids {snapshot_id} \
-        --filter 'Name=tag:Application,Values=testy' \
+        --filters 'Name=tag:Application,Values=testy' \
         --query 'Snapshots[*].SnapshotId' \
         --output text", hide=True, warn=True)
     if result.stderr:

--- a/services/scripts/testy-snapshot.sh
+++ b/services/scripts/testy-snapshot.sh
@@ -98,7 +98,7 @@ main() {
 
     # Validate database. Update the snapshot status on success/failure.
     aws ec2 create-tags --resources "$_snapshot_id" "$_volume_id" \
-                        --tags "Key=Validation,Value=none Key=InstanceID,Value=$_instance_id"
+                        --tags Key=Validation,Value=none Key=InstanceID,Value="$_instance_id"
 
     echo "Running validation script '$_validation_script' on volume '$_volume_id'."
     ts=$(date +%s%3N)

--- a/services/scripts/testy-snapshot.sh
+++ b/services/scripts/testy-snapshot.sh
@@ -108,11 +108,11 @@ main() {
                                 --log-stream-name testy-logs --log-events \
             timestamp=$ts,message="Backup snapshot validation succeeded. $_snapshot_id. $_instance_id"
         # We can delete the snapshot now it has been validated.
-        echo "Deleting snapshot '$snapshot_id' ..."
+        echo "Deleting snapshot '$_snapshot_id' ..."
         if aws ec2 delete-snapshot --snapshot-id "$_snapshot_id"; then
-            echo "Deleted snapshot '$snapshot_id'."
+            echo "Deleted snapshot '$_snapshot_id'."
         else
-            echo "Error: Failed to delete snapshot '$snapshot_id'."
+            echo "Error: Failed to delete snapshot '$_snapshot_id'."
         fi
     else
         echo "Validation failed for database backup snapshot '$_snapshot_id'."

--- a/services/scripts/testy-snapshot.sh
+++ b/services/scripts/testy-snapshot.sh
@@ -84,7 +84,7 @@ main() {
 
     # Validate database. Update the snapshot status on success/failure.
     aws ec2 create-tags --resources "$_snapshot_id" "$_volume_id" \
-                        --tags Key=Validation,Value=none
+                        --tags "Key=Validation,Value=none Key=InstanceID,Value=$_instance_id"
 
     echo "Running validation script '$_validation_script' on volume '$_volume_id'."
     var=$(date +%s%3N)

--- a/services/scripts/testy-snapshot.sh
+++ b/services/scripts/testy-snapshot.sh
@@ -38,6 +38,18 @@ main() {
         exit 1
     fi
 
+    # Delete any previous snapshots that have been succesffuly validated.
+    local _snapshot_ids
+    _snapshot_ids=$(aws ec2 describe-snapshots --filters "Name=tag:Application,Values=testy" \
+    "Name=tag:Validation,Values=failed" "Name=tag:InstanceID,Values=$_instance_id" \
+    --query "Snapshots[*].[SnapshotId]" --output text)
+    for snapshot_id in $_snapshot_ids; do
+        echo "Deleting snapshot '$snapshot_id' ..."
+        if ! aws ec2 delete-snapshot --snapshot-id "$snapshot_id"; then
+            echo "Error: Failed to delete snapshot '$snapshot_id'."
+        fi
+    done
+
     # Retrieve the tags from the instance.
     local _tags
     _tags=$(aws ec2 describe-instances --instance-ids "$_instance_id" \

--- a/services/scripts/testy-snapshot.sh
+++ b/services/scripts/testy-snapshot.sh
@@ -41,7 +41,7 @@ main() {
     # Delete any previous snapshots that have been successfully validated.
     local _snapshot_ids
     _snapshot_ids=$(aws ec2 describe-snapshots --filters "Name=tag:Application,Values=testy" \
-    "Name=tag:Validation,Values=failed" "Name=tag:InstanceID,Values=$_instance_id" \
+    "Name=tag:Validation,Values=success" "Name=tag:InstanceID,Values=$_instance_id" \
     --query "Snapshots[*].[SnapshotId]" --output text)
     for snapshot_id in $_snapshot_ids; do
         echo "Deleting snapshot '$snapshot_id' ..."

--- a/services/scripts/testy-snapshot.sh
+++ b/services/scripts/testy-snapshot.sh
@@ -106,7 +106,7 @@ main() {
         echo "Successfully validated database backup snapshot '$_snapshot_id'."
         aws logs put-log-events --log-group-name testy-logs \
                                 --log-stream-name testy-logs --log-events \
-            timestamp=$ts,message="Backup snapshot validation succeeded. $_snapshot_id. $_instance_id"
+            timestamp=$ts,message="Backup snapshot ($_snapshot_id) validation succeeded for instance '$_instance_id'."
         # We can delete the snapshot now it has been validated.
         echo "Deleting snapshot '$_snapshot_id' ..."
         if aws ec2 delete-snapshot --snapshot-id "$_snapshot_id"; then
@@ -118,7 +118,7 @@ main() {
         echo "Validation failed for database backup snapshot '$_snapshot_id'."
         aws logs put-log-events --log-group-name testy-logs \
                                 --log-stream-name testy-logs --log-events \
-            timestamp=$ts,message="Backup snapshot validation failed. $_snapshot_id. $_instance_id"
+            timestamp=$ts,message="Backup snapshot ($_snapshot_id) validation failed for instance '$_instance_id'."
     fi
 
     # Unmount the device, detach the volume and delete it when the validation is done. We
@@ -216,7 +216,7 @@ create_snapshot() {
             ts=$(date +%s%3N)
             aws logs put-log-events --log-group-name testy-logs \
                                     --log-stream-name snapshot-id --log-events \
-            timestamp=$ts,message="Testy backup failed. $__snapshot_id. $_instance_id"
+            timestamp=$ts,message="Testy backup ($__snapshot_id) failed for instance '$_instance_id'."
             return 1
         fi
 
@@ -230,7 +230,7 @@ create_snapshot() {
     ts=$(date +%s%3N)
     aws logs put-log-events --log-group-name testy-logs \
                             --log-stream-name snapshot-id --log-events \
-    timestamp=$ts,message="Testy backup succeeded. $__snapshot_id. $_instance_id"
+    timestamp=$ts,message="Testy backup ($__snapshot_id) succeeded for instance '$_instance_id'."
 }
 
 # Create a new EBS volume from the specified snapshot id that can be attached to

--- a/services/scripts/testy-snapshot.sh
+++ b/services/scripts/testy-snapshot.sh
@@ -7,11 +7,9 @@ main() {
 
     local _aws_endpoint
     local _instance_id
-    local _availability_zone
 
     _aws_endpoint="http://169.254.169.254/latest/meta-data/"
     _instance_id=$(curl ${_aws_endpoint}/instance-id 2> /dev/null)
-    _availability_zone=$(curl ${_aws_endpoint}/placement/availability-zone 2> /dev/null)
 
     echo "Starting database backup for instance '$_instance_id' ..."
 
@@ -60,8 +58,12 @@ main() {
 
     # Create a volume from the snapshot and if successful, attach it to the instance
     # and mount the device at the specificed mount point.
+    local _availability_zone
     local _mount_device
     local _volume_id
+
+    _availability_zone=$(curl ${_aws_endpoint}/placement/availability-zone 2> /dev/null)
+
     if create_volume_from_snapshot \
       "$_snapshot_id" "$_availability_zone" "$_instance_id" "$_tags" _volume_id
     then

--- a/services/scripts/testy-snapshot.sh
+++ b/services/scripts/testy-snapshot.sh
@@ -213,10 +213,10 @@ create_snapshot() {
         if [ $_wait_time -gt $_wait_timeout ]; then
             echo "Error: Waited $_wait_timeout seconds for snapshot '$__snapshot_id'" \
                  "to complete." 
-            var=$(date +%s%3N)
+            ts=$(date +%s%3N)
             aws logs put-log-events --log-group-name testy-logs \
                                     --log-stream-name snapshot-id --log-events \
-            timestamp=$var,message="Testy backup failed. $__snapshot_id. $_instance_id"
+            timestamp=$ts,message="Testy backup failed. $__snapshot_id. $_instance_id"
             return 1
         fi
 
@@ -227,10 +227,10 @@ create_snapshot() {
             --output text)
         ((_wait_time+=_wait_interval))
     done
-    var=$(date +%s%3N)
+    ts=$(date +%s%3N)
     aws logs put-log-events --log-group-name testy-logs \
                             --log-stream-name snapshot-id --log-events \
-    timestamp=$var,message="Testy backup succeeded. $__snapshot_id. $_instance_id"
+    timestamp=$ts,message="Testy backup succeeded. $__snapshot_id. $_instance_id"
 }
 
 # Create a new EBS volume from the specified snapshot id that can be attached to

--- a/services/scripts/testy-snapshot.sh
+++ b/services/scripts/testy-snapshot.sh
@@ -87,17 +87,21 @@ main() {
                         --tags "Key=Validation,Value=none Key=InstanceID,Value=$_instance_id"
 
     echo "Running validation script '$_validation_script' on volume '$_volume_id'."
-    var=$(date +%s%3N)
+    ts=$(date +%s%3N)
     if validate_database "$_validation_script" "$_mount_point" "$_snapshot_id" "$_volume_id"; then
         echo "Successfully validated database backup snapshot '$_snapshot_id'."
         aws logs put-log-events --log-group-name testy-logs \
                                 --log-stream-name testy-logs --log-events \
-            timestamp=$var,message="Backup snapshot validation succeeded. $_snapshot_id. $_instance_id"
+            timestamp=$ts,message="Backup snapshot validation succeeded. $_snapshot_id. $_instance_id"
+        # We can delete the snapshot now it has been validated.
+        if ! aws ec2 delete-snapshot --snapshot-id "$_snapshot_id"; then
+            echo "Error: Failed to delete snapshot '$snapshot_id'."
+        fi
     else
         echo "Validation failed for database backup snapshot '$_snapshot_id'."
         aws logs put-log-events --log-group-name testy-logs \
                                 --log-stream-name testy-logs --log-events \
-            timestamp=$var,message="Backup snapshot validation failed. $_snapshot_id. $_instance_id"
+            timestamp=$ts,message="Backup snapshot validation failed. $_snapshot_id. $_instance_id"
     fi
 
     # Unmount the device, detach the volume and delete it when the validation is done. We

--- a/services/scripts/testy-snapshot.sh
+++ b/services/scripts/testy-snapshot.sh
@@ -106,7 +106,7 @@ main() {
         echo "Successfully validated database backup snapshot '$_snapshot_id'."
         aws logs put-log-events --log-group-name testy-logs \
                                 --log-stream-name testy-logs --log-events \
-            timestamp=$ts,message="Backup snapshot ($_snapshot_id) validation succeeded for instance '$_instance_id'."
+            timestamp=$ts,message="Backup snapshot ($_snapshot_id) validation succeeded for instance $_instance_id."
         # We can delete the snapshot now it has been validated.
         echo "Deleting snapshot '$_snapshot_id' ..."
         if aws ec2 delete-snapshot --snapshot-id "$_snapshot_id"; then
@@ -118,7 +118,7 @@ main() {
         echo "Validation failed for database backup snapshot '$_snapshot_id'."
         aws logs put-log-events --log-group-name testy-logs \
                                 --log-stream-name testy-logs --log-events \
-            timestamp=$ts,message="Backup snapshot ($_snapshot_id) validation failed for instance '$_instance_id'."
+            timestamp=$ts,message="Backup snapshot ($_snapshot_id) validation failed for instance $_instance_id."
     fi
 
     # Unmount the device, detach the volume and delete it when the validation is done. We
@@ -216,7 +216,7 @@ create_snapshot() {
             ts=$(date +%s%3N)
             aws logs put-log-events --log-group-name testy-logs \
                                     --log-stream-name snapshot-id --log-events \
-            timestamp=$ts,message="Testy backup ($__snapshot_id) failed for instance '$_instance_id'."
+            timestamp=$ts,message="Testy backup ($__snapshot_id) failed for instance $_instance_id."
             return 1
         fi
 
@@ -230,7 +230,7 @@ create_snapshot() {
     ts=$(date +%s%3N)
     aws logs put-log-events --log-group-name testy-logs \
                             --log-stream-name snapshot-id --log-events \
-    timestamp=$ts,message="Testy backup ($__snapshot_id) succeeded for instance '$_instance_id'."
+    timestamp=$ts,message="Testy backup ($__snapshot_id) succeeded for instance $_instance_id."
 }
 
 # Create a new EBS volume from the specified snapshot id that can be attached to

--- a/services/scripts/testy-snapshot.sh
+++ b/services/scripts/testy-snapshot.sh
@@ -38,14 +38,16 @@ main() {
         exit 1
     fi
 
-    # Delete any previous snapshots that have been succesffuly validated.
+    # Delete any previous snapshots that have been successfully validated.
     local _snapshot_ids
     _snapshot_ids=$(aws ec2 describe-snapshots --filters "Name=tag:Application,Values=testy" \
     "Name=tag:Validation,Values=failed" "Name=tag:InstanceID,Values=$_instance_id" \
     --query "Snapshots[*].[SnapshotId]" --output text)
     for snapshot_id in $_snapshot_ids; do
         echo "Deleting snapshot '$snapshot_id' ..."
-        if ! aws ec2 delete-snapshot --snapshot-id "$snapshot_id"; then
+        if aws ec2 delete-snapshot --snapshot-id "$snapshot_id"; then
+            echo "Deleted snapshot '$snapshot_id'."
+        else
             echo "Error: Failed to delete snapshot '$snapshot_id'."
         fi
     done
@@ -106,7 +108,10 @@ main() {
                                 --log-stream-name testy-logs --log-events \
             timestamp=$ts,message="Backup snapshot validation succeeded. $_snapshot_id. $_instance_id"
         # We can delete the snapshot now it has been validated.
-        if ! aws ec2 delete-snapshot --snapshot-id "$_snapshot_id"; then
+        echo "Deleting snapshot '$snapshot_id' ..."
+        if aws ec2 delete-snapshot --snapshot-id "$_snapshot_id"; then
+            echo "Deleted snapshot '$snapshot_id'."
+        else
             echo "Error: Failed to delete snapshot '$snapshot_id'."
         fi
     else


### PR DESCRIPTION
- Use `filters` instead of `filter` to comply with the documentation
- Delete the newly created snapshot if its validation is successful
- Delete any previous snapshots that were successfully validated in the past from the same instance ID