### PR TITLE
WTBUILD-112 Extend API to name/terminate an instance

### DIFF
--- a/fabfile.py
+++ b/fabfile.py
@@ -7,7 +7,7 @@ from invoke.exceptions import Exit
 from invocations.console import confirm
 from fabric import Connection, task
 from pathlib import Path
-from scripts.testy_launch import get_instances_info, get_launch_templates, get_snapshots, launch_from_distro, \
+from scripts.testy_launch import get_instance_id_from_name, get_instances_info, get_launch_templates, get_snapshots, launch_from_distro, \
     launch_from_snapshot, terminate_instance
 
 testy = "\033[1;36mtesty\033[0m"
@@ -73,7 +73,23 @@ def launch_snapshot(c, snapshot_id):
 
 # Terminate an AWS instance.
 @task
-def terminate(c, instance_id):
+def terminate(c, instance_id=None, instance_name=None):
+    if not instance_id and not instance_name:
+        print("Missing arguments, please use the --help option to read about the command.")
+        return
+
+    if instance_id and instance_name:
+        print("Only specify one argument, please use the --help option to read about the command.")
+        return
+
+    if instance_name is not None:
+        if not instance_name:
+            print("The given instance_name is invalid")
+            return
+
+        # Retrieve the instance id.
+        instance_id = get_instance_id_from_name(instance_name)
+
     try:
         terminate_instance(instance_id)
     except Exception as e:

--- a/fabfile.py
+++ b/fabfile.py
@@ -82,12 +82,8 @@ def terminate(c, instance_id=None, instance_name=None):
         print("Only specify one argument, please use the --help option to read about the command.")
         return
 
-    if instance_name is not None:
-        if not instance_name:
-            print("The given instance_name is invalid")
-            return
-
-        # Retrieve the instance id.
+    if instance_id is None:
+        # Retrieve the instance id using the name.
         instance_id = get_instance_id_from_name(instance_name)
 
     try:

--- a/fabfile.py
+++ b/fabfile.py
@@ -7,7 +7,7 @@ from invoke.exceptions import Exit
 from invocations.console import confirm
 from fabric import Connection, task
 from pathlib import Path
-from scripts.testy_launch import get_launch_templates, get_snapshots, launch_from_distro, \
+from scripts.testy_launch import get_instances_info, get_launch_templates, get_snapshots, launch_from_distro, \
     launch_from_snapshot, terminate_instance
 
 testy = "\033[1;36mtesty\033[0m"
@@ -429,15 +429,16 @@ def snapshot_delete(c, snapshot_id=None):
             raise Exit(result.stderr)
         print(f"Deleted snapshot '{snapshot_id}'.")       
 
-# The list function takes three optional arguments: distros, snapshots and workloads.
+# The list function takes the following optional arguments:
 #    --distros    List the available distributions for launching a testy server.
+#    --instances  Give information about the existing instances.
 #    --snapshots  List the snapshots created from scheduled backups, validation failure,
 #                 and wiredtiger failure.
 #    --workloads  List the workloads available on the specified testy server. The -H
 #                 option is required.
 @task
-def list(c, distros=False, snapshots=False, workloads=False):
-    if not distros and not snapshots and not workloads:
+def list(c, distros=False, instances=False, snapshots=False, workloads=False):
+    if not distros and not instances and not snapshots and not workloads:
         print("Missing arguments, please use the --help option to read about the command.")
         return
 
@@ -451,9 +452,22 @@ def list(c, distros=False, snapshots=False, workloads=False):
             print("\n\033[1mAvailable distros: \033[0m")
             if launch_templates:
                 for template in launch_templates:
-                    print(f"{template}")
+                    print(template)
             else:
                 print("No launch templates found.")
+
+    if instances:
+        instances_info = None
+        try:
+            instances_info = get_instances_info()
+        except Exception as e:
+            print(f"Error: {str(e)}")
+        else:
+            print("\n\033[1mAvailable instances: \033[0m")
+            if instances_info:
+                print(instances_info)
+            else:
+                print("No instances found.")
 
     if snapshots:
         snapshots = None
@@ -465,7 +479,7 @@ def list(c, distros=False, snapshots=False, workloads=False):
             print("\n\033[1mAvailable snapshots: \033[0m")
             if snapshots:
                 for snapshot in snapshots:
-                    print(f"{snapshot}")
+                    print(snapshot)
             else:
                 print("No snapshots found.")
 

--- a/fabfile.py
+++ b/fabfile.py
@@ -469,11 +469,9 @@ def snapshot_delete(c, snapshot_id=None):
 #                 and wiredtiger failure.
 #    --workloads  List the workloads available on the specified testy server. The -H
 #                 option is required.
+# By default, the list function does not print anything.
 @task
 def list(c, distros=False, instances=False, snapshots=False, workloads=False):
-    if not distros and not instances and not snapshots and not workloads:
-        print("Missing arguments, please use the --help option to read about the command.")
-        return
 
     if distros:
         launch_templates = None

--- a/fabfile.py
+++ b/fabfile.py
@@ -20,13 +20,13 @@ wiredtiger = "\033[1;33mwiredtiger\033[0m"
 
 # Launch an AWS instance and install testy using the given WiredTiger and testy branches.
 @task
-def launch(c, distro, iam_profile=None, wiredtiger_branch="develop", testy_branch="main"):
+def launch(c, distro, instance_name=None, iam_profile=None, wiredtiger_branch="develop", testy_branch="main"):
 
     # Check for invalid IAM profiles.
     if iam_profile is not None and not iam_profile:
         raise Exit(f"The IAM profile '{iam_profile}' is invalid.")
 
-    result = launch_from_distro(distro, iam_profile)
+    result = launch_from_distro(distro, instance_name, iam_profile)
     if result['status'] != 0:
         print(f"Launch failed. {result['msg']}")
         return

--- a/fabfile.py
+++ b/fabfile.py
@@ -82,8 +82,7 @@ def terminate(c, instance_id=None, instance_name=None):
         print("Only specify one argument, please use the --help option to read about the command.")
         return
 
-    if instance_id is None:
-        # Retrieve the instance id using the name.
+    if not instance_id:
         instance_id = get_instance_id_from_name(instance_name)
 
     try:

--- a/fabfile.py
+++ b/fabfile.py
@@ -8,7 +8,7 @@ from invocations.console import confirm
 from fabric import Connection, task
 from pathlib import Path
 from scripts.testy_launch import get_launch_templates, get_snapshots, launch_from_distro, \
-    launch_from_snapshot
+    launch_from_snapshot, terminate_instance
 
 testy = "\033[1;36mtesty\033[0m"
 testy_config = ".testy"
@@ -66,6 +66,14 @@ def launch_snapshot(c, snapshot_id):
     print(f"The host is '{hostname}'")
     print(f"The instance id is '{result['instance_id']}'")
     print(f"The instance name is '{result['instance_name']}'\n")
+
+# Terminate an AWS instance.
+@task
+def terminate(c, instance_id):
+    try:
+        terminate_instance(instance_id)
+    except Exception as e:
+        print(f"Error: {str(e)}")
 
 # Install the testy framework.
 @task

--- a/scripts/testy_launch.py
+++ b/scripts/testy_launch.py
@@ -83,6 +83,18 @@ def get_tag_value_from_resource(resource_id, key):
         raise Exit(f"Unable to retrieve value for key '{key}' from resource '{resource_id}'")
     return value
 
+def get_instance_id_from_name(name):
+    result = local(f"aws ec2 describe-instances \
+        --filters Name=tag:Name,Values={name} \
+        --query 'Reservations[*].Instances[*].InstanceId' \
+        --output text", hide=True, warn=True)
+    if result.stderr:
+        raise Exit(result.stderr)
+    value = result.stdout.strip()
+    if not value:
+        raise Exit(f"Unable to retrieve the instance ID from the name '{name}'.")
+    return value
+
 def get_volume_id_from_instance(instance_id):
     result = local(f"aws ec2 describe-volumes \
         --filters Name=attachment.instance-id,Values={instance_id} \

--- a/scripts/testy_launch.py
+++ b/scripts/testy_launch.py
@@ -322,7 +322,7 @@ def terminate_instance(instance_id):
     if status == 'shutting-down':
         print(f"The instance '{instance_id}' is shutting down.")
     elif status == 'terminated':
-        print(f"The instance '{instance_id}' is already terminated.")
+        print(f"The instance '{instance_id}' is terminating.")
 
 if __name__ == "__main__":
 

--- a/scripts/testy_launch.py
+++ b/scripts/testy_launch.py
@@ -208,7 +208,7 @@ def attach_iam_profile(instance_id, iam_profile):
 # contains a user-friendly error message.
 
 # Launch an AWS instance given a distro.
-def launch_from_distro(distro, iam_profile):
+def launch_from_distro(distro, instance_name, iam_profile):
 
     if not launch_template_exists(distro):
         return {"status": 1, "msg": f"The distro '{distro}' does not exist."}
@@ -237,7 +237,8 @@ def launch_from_distro(distro, iam_profile):
 
         # Add 'Name' tags for the new instance and volume.
         volume_id = get_volume_id_from_instance(instance_id)
-        instance_name = f"testy-{distro}-{instance_id.replace('-','')}"
+        if not instance_name:
+            instance_name = f"testy-{distro}-{instance_id.replace('-','')}"
         set_tag_for_resource(instance_id, "Name", instance_name)
         set_tag_for_resource(volume_id, "Name", f"testy-{distro}-{volume_id.replace('-','')}")
 

--- a/scripts/testy_launch.py
+++ b/scripts/testy_launch.py
@@ -23,6 +23,16 @@ def get_image_id(image_name):
     image_id = result.stdout.strip()
     return image_id
 
+# Get information about existing instances.
+def get_instances_info():
+    result = local("aws ec2 describe-instances \
+        --filters Name=instance-state-name,Values=running \
+        --query 'Reservations[*].Instances[*].{Instance:InstanceId,Name:Tags[?Key==`Name`]|[0].Value}' \
+        --output text", hide=True, warn=True)
+    if result.stderr:
+        raise Exit(result.stderr)
+    return result.stdout.strip()
+
 # Get all the available launch templates and return the result as a list.
 def get_launch_templates():
     result = local("aws ec2 describe-launch-templates \

--- a/scripts/testy_launch.py
+++ b/scripts/testy_launch.py
@@ -265,6 +265,20 @@ def launch_from_snapshot(snapshot_id):
     return {"status": 0, "user": user, "hostname": hostname,
         "instance_id": instance_id, "instance_name": instance_name}
 
+# Terminate an AWS instance given its ID.
+def terminate_instance(instance_id):
+    result = local(f"aws ec2 terminate-instances \
+        --instance-ids {instance_id} \
+        --query 'TerminatingInstances[*].CurrentState.Name' \
+        --output text", hide=True, warn=True)
+    if result.stderr:
+        raise Exit(result.stderr)
+    status = result.stdout.strip()
+    if status == 'shutting-down':
+        print(f"The instance '{instance_id}' is shutting down.")
+    elif status == 'terminated':
+        print(f"The instance '{instance_id}' is already terminated.")
+
 if __name__ == "__main__":
 
     globals()[sys.argv[1]](*sys.argv[2:])


### PR DESCRIPTION
New commands:
```
# Create an instance with a name
fab launch ubuntu2204  --instance-name="my beautiful instance"

# List instances
fab list -i
---
Available instances: 
<instance_id>    testy-wt-10957-try-dropping-x86-barriers
---

# Terminate using the ID
fab terminate -i i-00adafeeff988285b

# Terminate using the name
fab terminate -n testy-ubuntu2204-i0a4ffeaf1afb3da87
```